### PR TITLE
Added checkbox for keeping the aspect ratio when resizing an uploaded image

### DIFF
--- a/qr_editor/static/qr_editor/css/style.css
+++ b/qr_editor/static/qr_editor/css/style.css
@@ -107,6 +107,7 @@ body {
 
 #upload-popup {
     text-align: left;
+    max-width: 470;
 }
 
 .num-input {

--- a/qr_editor/static/qr_editor/js/main.js
+++ b/qr_editor/static/qr_editor/js/main.js
@@ -507,8 +507,21 @@ class Canvas {
         $('#image-x').val(coords[0]);
         $('#image-y').val(coords[1]);
         $('#image-width').val(coords[2]);
+        var previousWidth = $("#image-width").val();
         $('#image-height').val(coords[3]);
+        var previousHeight = $("#image-height").val();
         let handleChange = () => {
+          //Handles aspect ratio
+          if($("#image-keep-aspect").is(":checked")){
+            if($("#image-width").val() != previousWidth){
+              $("#image-height").val($("#image-height").val() * $("#image-width").val()/previousWidth);
+            }else if($("#image-height").val() != previousHeight){
+              $("#image-width").val($("#image-width").val() * $("#image-height").val()/previousHeight);
+            }
+          }
+          previousWidth = $("#image-width").val();
+          previousHeight = $("#image-height").val();
+
           let previewCanvas = _this.getPreviewCanvas(uimg);
           let canvasContainer = document.getElementById("canvas-container");
           canvasContainer.innerHTML = "";

--- a/qr_editor/templates/qr_editor/index.html
+++ b/qr_editor/templates/qr_editor/index.html
@@ -91,6 +91,9 @@
           <input class="num-input" type="number" min="0" id="image-y" name="image-y" />
           <label for="image-x">Y</label><br>
 
+          <input class="checkbox-input" type="checkbox" value="off" id="image-keep-aspect" name="image-keep-aspect" />
+          <label for="image-keep-aspect">Keep aspect ratio</label><br>
+
           <input class="num-input" type="number" min="0" id="image-width" name="image-width" />
           <label for="image-x">Width</label><br>
 


### PR DESCRIPTION
Added checkbox for keeping the aspect ratio when resizing an uploaded image

Whenever the image popup handles changes, it checks if the checkbox for keeping the aspect ratio has been checked.
If it has been checked, it checks if there has been a change en the width or height, and then calculates what the other attribute should be to keep the aspect ratio,

Also changed the width of the upload-popup so that it doesn't wrap the canvas because of the width of the label.